### PR TITLE
Ot 91 add init with config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2023-03-08
+
+### Changed in 0.3.1
+
+- Added initWithG2Config method for initializing G2 with json configuration string instead of path to the G2 ini file
+
 ## [0.3.0] - 2022-09-29
 
 ### Changed in 0.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-listener</artifactId>
   <packaging>jar</packaging>
-  <version>0.3.0</version>
+  <version>0.3.1</version>
   <name>Senzing Listener Framework</name>
   <description>Framework for creating applications receiving messages from G2 through queue</description>
   <url>http://github.com/Senzing/senzing-listener</url>

--- a/src/main/java/com/senzing/listener/service/g2/G2Service.java
+++ b/src/main/java/com/senzing/listener/service/g2/G2Service.java
@@ -46,7 +46,6 @@ public class G2Service {
    * @throws ServiceSetupException If a failure occurs.
    */
   public void init(String iniFile) throws ServiceSetupException {
-    boolean verboseLogging = false;
 
     String configData = null;
     try {
@@ -54,8 +53,21 @@ public class G2Service {
     } catch (IOException | RuntimeException e) {
       throw new ServiceSetupException(e);
     }
+    initWithG2Config(configData);
+  }
+
+  /**
+   * Initializes the service. The configuration information is passed in as a json string.
+   *
+   * @param g2Config configuration as a json string.
+   *
+   * @throws ServiceSetupException If a failure occurs.
+   */
+  public void initWithG2Config(String g2Config) throws ServiceSetupException {
+    boolean verboseLogging = false;
+
     g2Engine = new G2JNI();
-    int result = g2Engine.init(moduleName, configData, verboseLogging);
+    int result = g2Engine.init(moduleName, g2Config, verboseLogging);
     if (result != G2ServiceDefinitions.G2_VALID_RESULT) {
       StringBuilder errorMessage = new StringBuilder("G2 engine failed to initalize with error: ");
       errorMessage.append(g2ErrorMessage(g2Engine));


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #91

## Why was change needed

G2 could only be initialized with ini file.  This change adds initialization with configuration string.

## What does change improve

Adds initialization using configuration string. Very useful for Docker images.
