### PR TITLE
Version 0.5.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2023-10-13
+
+### Changed in 0.5.2
+
+- Changed dependency on `senzing-commons` to a minimum version of `3.1.2` to address 
+  bug related to setting SQLite timestamp values.
+- Streamlined message consumptio throttling in `AbstractMessageConsumer` to wait until 
+  pending count falls below half of the maximum value.
+- Fixed `RabbitMQMessageConsumer` to override throttling by doing a `basicCancel()` and
+  then do a `basicConsume()` when pending message count drops.  This prevents RabbitMQ
+  from timing out the connection (especially with SQLite since we only have one database
+  connection to work with)
+- Updated third-party dependencies to newer versions.
+
 ## [0.5.1] - 2023-09-30
 
 ### Changed in 0.5.1

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-listener</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.1</version>
+  <version>0.5.2</version>
   <name>Senzing Listener Framework</name>
   <description>Framework for creating applications receiving messages from G2 through queue</description>
   <url>http://github.com/Senzing/senzing-listener</url>
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.1.1, 3.999.999]</version>
+      <version>[3.1.2, 3.999.999]</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -89,82 +89,82 @@
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.18.0</version>
+      <version>5.19.0</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.20.147</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.20.157</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>auth</artifactId>
-      <version>2.20.147</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-query-protocol</artifactId>
-      <version>2.20.147</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>protocol-core</artifactId>
-      <version>2.20.157</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
-      <version>2.20.147</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
-      <version>2.20.147</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>regions</artifactId>
-      <version>2.20.157</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>json-utils</artifactId>
-      <version>2.20.147</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>annotations</artifactId>
-      <version>2.20.147</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>utils</artifactId>
-      <version>2.20.157</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
-      <version>2.20.147</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>metrics-spi</artifactId>
-      <version>2.20.147</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>endpoints-spi</artifactId>
-      <version>2.20.157</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>profiles</artifactId>
-      <version>2.20.147</version>
+      <version>2.20.162</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.eventstream</groupId>


### PR DESCRIPTION
- Changed dependency on `senzing-commons` to a minimum version of `3.1.2` to address bug related to setting SQLite timestamp values.
- Streamlined message consumptio throttling in `AbstractMessageConsumer` to wait until pending count falls below half of the maximum value.
- Fixed `RabbitMQMessageConsumer` to override throttling by doing a `basicCancel()` and then do a `basicConsume()` when pending message count drops.  This prevents RabbitMQ from timing out the connection (especially with SQLite since we only have one database connection to work with)
- Updated third-party dependencies to newer versions.
