### PR TITLE
Version 0.5.3 - Adds SQL-based Message Queue Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea
 bin/
 .history
+.vscode/

--- a/.project
+++ b/.project
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
 	<name>senzing-listener</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1697646280652</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2023-12-07
+
+### Changed in 0.5.3
+
+- Changed `sqlite-jdbc` dependency to version `3.42.0.1` to avoid the problematic
+  version `3.43.x.x` which carelessly breaks backwards compatibility by removing
+  functionality that has been supported for sixteen (16) years. 
+- Added `com.senzing.listener.communication.sql.SQLConsumer` implementation of 
+  `com.senzing.listener.communication.MessageConsumer`.  
+- Made `G2Service.getG2InitDataAsJson(String)` function `public` and renamed the
+  function from `getG2IniDataAsJson(String)`
+- Added `ConsumerType.DATABASE` enumerated constant for `SQLConsumer`.
+- Updated `MessageConsumerFactory` to support `ConsumerType.DATABASE` constant 
+  and creation of `SQLConsumer` instances.
+
 ## [0.5.2] - 2023-10-13
 
 ### Changed in 0.5.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV REFRESHED_AT=2023-11-14
 
 LABEL Name="senzing/senzing-listener-builder" \
       Maintainer="support@senzing.com" \
-      Version="0.5.1"
+      Version="0.5.3"
 
 # Set environment variables.
 
@@ -39,7 +39,7 @@ ENV REFRESHED_AT=2023-11-14
 
 LABEL Name="senzing/senzing-listener" \
       Maintainer="support@senzing.com" \
-      Version="0.5.1"
+      Version="0.5.3"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-listener</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.2</version>
+  <version>0.5.3</version>
   <name>Senzing Listener Framework</name>
   <description>Framework for creating applications receiving messages from G2 through queue</description>
   <url>http://github.com/Senzing/senzing-listener</url>
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.1.2, 3.999.999]</version>
+      <version>[3.1.4, 3.999.999]</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -185,7 +185,7 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.43.0.0</version>
+      <version>3.42.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.20.147</version>
+        <version>2.21.40</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -89,82 +89,82 @@
     <dependency>
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
-      <version>5.19.0</version>
+      <version>5.20.0</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>auth</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-query-protocol</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>protocol-core</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>regions</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>json-utils</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>annotations</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>utils</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>metrics-spi</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>endpoints-spi</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>profiles</artifactId>
-      <version>2.20.162</version>
+      <version>2.21.40</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.eventstream</groupId>
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.10.0</version>
+      <version>5.10.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -191,7 +191,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.6.0</version>
+      <version>42.7.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/senzing/listener/communication/AbstractMessageConsumer.java
+++ b/src/main/java/com/senzing/listener/communication/AbstractMessageConsumer.java
@@ -482,7 +482,7 @@ public abstract class AbstractMessageConsumer<M> implements MessageConsumer
    *         throttling consumption.
    */
   protected synchronized int getMaximumPendingCount() {
-    return this.concurrency * 10;
+    return this.concurrency * 1000;
   }
 
   /**
@@ -945,7 +945,7 @@ public abstract class AbstractMessageConsumer<M> implements MessageConsumer
   }
 
   /**
-   * Enqueues the one or info messages contained in the specified
+   * Enqueues the one or more info messages contained in the specified
    * framework-specific message.  If the message text is <code>null</code>
    * or empty-string then this method does nothing.  If the message text
    * contains text that cannot be parsed as JSON then the unrecognized message

--- a/src/main/java/com/senzing/listener/communication/ConsumerType.java
+++ b/src/main/java/com/senzing/listener/communication/ConsumerType.java
@@ -5,6 +5,11 @@ package com.senzing.listener.communication;
  */
 public enum ConsumerType {
   /**
+   * Uses for database message queuue via <code>sz_message_queue</code> table.
+   */
+  DATABASE,
+
+  /**
    * Used for Rabbit MQ.
    */
   RABBIT_MQ,

--- a/src/main/java/com/senzing/listener/communication/MessageConsumerFactory.java
+++ b/src/main/java/com/senzing/listener/communication/MessageConsumerFactory.java
@@ -3,6 +3,7 @@ package com.senzing.listener.communication;
 import com.senzing.listener.communication.exception.MessageConsumerSetupException;
 import com.senzing.listener.communication.rabbitmq.RabbitMQConsumer;
 import com.senzing.listener.communication.sqs.SQSConsumer;
+import com.senzing.listener.communication.sql.SQLConsumer;
 
 import javax.json.JsonObject;
 
@@ -30,6 +31,9 @@ public class MessageConsumerFactory {
     MessageConsumer consumer = null;
 
     switch (consumerType) {
+      case DATABASE:
+        consumer = new SQLConsumer();
+        break;
       case RABBIT_MQ:
         consumer = new RabbitMQConsumer();
         break;

--- a/src/main/java/com/senzing/listener/communication/sql/LeasedMessage.java
+++ b/src/main/java/com/senzing/listener/communication/sql/LeasedMessage.java
@@ -1,0 +1,101 @@
+package com.senzing.listener.communication.sql;
+
+import java.io.Serializable;
+
+/**
+ * Provides a simple message implementation representing a message
+ * that has been stored in a database table and leased for consumption.
+ */
+public class LeasedMessage implements Serializable {
+    /**
+     * The unique ID identifying the message in the database.
+     */
+    private long messageId;
+
+    /**
+     * The lease ID identifying the lease for the message.
+     */
+    private String leaseId;
+
+    /**
+     * The millisecond UTC time for the expiration of the lease on
+     * this message.
+     */
+    private long leaseExpiration;
+
+    /**
+     * The message text.
+     */
+    private String messageText;
+
+    /**
+     * Constructs with the specified parameters.
+     * 
+     * @param messageId The unique ID identifying the message in the database.
+     * @param messageText The message text.
+     * @param leaseId The lease ID identifying the lease for the message.
+     * @param leaseExpiration The millisecond UTC time for the expiration of
+     *                        the lease on this message.
+     */
+    public LeasedMessage(long       messageId, 
+                         String     messageText,
+                         String     leaseId,
+                         long       leaseExpiration)   
+    {
+        this.messageId          = messageId;
+        this.messageText        = messageText;
+        this.leaseId            = leaseId;
+        this.leaseExpiration    = leaseExpiration;
+    }
+    
+    /**
+     * Gets the unique message ID that has been assigned to this 
+     * message in the database.
+     * 
+     * @return The unique message ID that has been assigned to this 
+     *         message in the database.
+     */
+    public long getMessageId() {
+        return this.messageId;
+    }
+
+    /**
+     * Gets the lease ID for the lease on this message.
+     * 
+     * @return the lease ID for the lease on this message.
+     */
+    public String getLeaseId() {
+        return this.leaseId;
+    }
+
+    /**
+     * Gets the millisecond UTC time indicating when the lease on this message
+     * will expire.
+     * 
+     * @return The millisecond UTC time indicating when the lease on this message
+     *         will expire.
+     */
+    public long getLeaseExpiration() {
+        return this.leaseExpiration;
+    }
+    
+    /**
+     * Sets the millisecond UTC time indicating the updated time when the lease
+     * on this message will expire.
+     * 
+     * @param leaseExpiration The millisecond UTC time when the lease on the 
+     *                        message will expire.
+     */
+    public void extendLease(long leaseExpiration) {
+        this.leaseExpiration = leaseExpiration;
+    }
+
+    /**
+     * Gets the text for the message.
+     * 
+     * @return The text for the message.
+     */
+    public String getMessageText() {
+        return this.messageText;
+    }
+}

--- a/src/main/java/com/senzing/listener/communication/sql/PostgreSQLClient.java
+++ b/src/main/java/com/senzing/listener/communication/sql/PostgreSQLClient.java
@@ -1,0 +1,134 @@
+package com.senzing.listener.communication.sql;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.LinkedList;
+
+import com.senzing.sql.DatabaseType;
+
+import static com.senzing.sql.SQLUtilities.*;
+import static com.senzing.util.LoggingUtilities.*;
+
+/**
+ * Provides a PostgreSQL implementation of {@link SQLClient}.
+ */
+public class PostgreSQLClient implements SQLClient {
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Implemented to return {@link DatabaseType#POSTGRESQL}.
+     * </p>
+     */
+    @Override
+    public DatabaseType getDatabaseType() {
+        return DatabaseType.POSTGRESQL;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Implemented to create the schema for the PostgreSQL database.
+     * </p>
+     */
+    @Override
+    public void ensureSchema(Connection conn, boolean recreate) 
+        throws SQLException 
+    {
+        String createTableSql = "CREATE TABLE IF NOT EXISTS sz_message_queue ("
+            + "message_id BIGSERIAL PRIMARY KEY, "
+            + "lease_id TEXT, "
+            + "expire_lease_at TIMESTAMP, "
+            + "message_text TEXT NOT NULL, "
+            + "created_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
+            + "modified_on TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP);";
+
+        String dropTableSql = "DROP TABLE IF EXISTS sz_message_queue;";
+
+        String createIndexSql = "CREATE INDEX IF NOT EXISTS sz_msg_queue_lease "
+            + "ON sz_message_queue (lease_id);";
+        
+        String dropIndexSql = "DROP INDEX IF EXISTS sz_msg_queue_lease;";
+
+        String createTriggerFunctionSql =
+            "CREATE OR REPLACE FUNCTION sz_msg_queue_timestamps() "
+                + "RETURNS TRIGGER "
+                + "LANGUAGE PLPGSQL "
+                + "AS $$ "
+                + "BEGIN "
+                + "  IF (TG_OP = 'UPDATE') THEN "
+                + "  BEGIN "
+                + "    NEW.created_on := OLD.created_on; "
+                + "    NEW.modified_on := CURRENT_TIMESTAMP; "
+                + "    return NEW; "
+                + "  END; "
+                + "ELSIF (TG_OP = 'INSERT') THEN "
+                + "  BEGIN "
+                + "    NEW.created_on := CURRENT_TIMESTAMP; "
+                + "    NEW.modified_on := CURRENT_TIMESTAMP; "
+                + "    return NEW; "
+                + "  END; "
+                + "END IF; "
+                + "RETURN NULL; "
+                + "END; "
+                + "$$;";
+    
+        String createTriggerSql =
+            "CREATE OR REPLACE TRIGGER sz_msg_queue_trigger "
+                + "  BEFORE INSERT OR UPDATE "
+                + "  ON sz_message_queue "
+                + "  FOR EACH ROW "
+                + "  WHEN (pg_trigger_depth() = 0) "
+                + "  EXECUTE PROCEDURE sz_msg_queue_timestamps();";
+    
+        String dropTriggerFunctionSql =
+            "DROP FUNCTION IF EXISTS sz_msg_queue_timestamps;";
+
+        String dropTriggerSql =
+            "DROP TRIGGER IF EXISTS sz_msg_queue_trigger "
+                + "ON sz_message_queue;";
+
+
+        List<String> sqlList = new ArrayList<>();
+
+        if (recreate) {
+            sqlList.add(dropTriggerSql);
+            sqlList.add(dropTriggerFunctionSql);
+            sqlList.add(dropIndexSql);
+            sqlList.add(dropTableSql);
+        }
+        sqlList.add(createTableSql);
+        sqlList.add(createIndexSql);
+        sqlList.add(createTriggerFunctionSql);
+        sqlList.add(createTriggerSql);
+      
+        // execute the statements
+        Statement stmt = null;
+        try {
+            // create the statement
+            stmt = conn.createStatement();
+        
+            // execute the SQL statements
+            for (String sql : sqlList) {
+                try {
+                  stmt.execute(sql);
+                } catch (SQLException e) {
+                  logError(e, "SQL Error Encountered: ", sql);
+                  throw e;
+                }
+            }
+        
+            // commit the connection
+            conn.commit();
+        
+        } finally {
+            stmt = close(stmt);
+        }
+    }
+}

--- a/src/main/java/com/senzing/listener/communication/sql/SQLClient.java
+++ b/src/main/java/com/senzing/listener/communication/sql/SQLClient.java
@@ -1,0 +1,392 @@
+package com.senzing.listener.communication.sql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.LinkedList;
+import java.util.Objects;
+
+import com.senzing.sql.DatabaseType;
+
+import static com.senzing.sql.SQLUtilities.*;
+
+/**
+ * Interface for adapting the {@link SQLConsumer} to a specific database.
+ */
+interface SQLClient {
+    /**
+     * Gets the {@link DatabaseType} for this client implementation.
+     * 
+     * @return The {@link DatabaseType} for this client implementation.
+     */
+    DatabaseType getDatabaseType();
+    
+    /**
+     * Ensures the schema required for managing the message queue exists.
+     * 
+     * @param conn The {@link Connection} to use.
+     * 
+     * @param recreate <code>true</code> if the schema should be dropped and
+     *                 recreated, <code>false</code> if it should just be
+     *                 created if it does not exist.
+     * 
+     * @throws SQLException If a database failure occurs.
+     */
+    void ensureSchema(Connection conn, boolean recreate) throws SQLException;
+
+    /**
+     * Checks if the message queue is empty.
+     * 
+     * @param conn The {@link Connection} to use.
+     * 
+     * @throws SQLException If a database failure occurs.
+     */
+    default boolean isQueueEmpty(Connection conn) throws SQLException {
+        PreparedStatement ps = null;
+        ResultSet         rs = null;
+        try {
+            // check if we can find at least one row
+            ps = conn.prepareStatement(
+                "SELECT 1 FROM sz_message_queue LIMIT 1");
+
+            rs = ps.executeQuery();
+
+            return (!rs.next());
+
+        } finally {
+            rs = close(rs);
+            ps = close(ps);
+        }
+    }
+
+    /**
+     * Gets the number of messages currently in the message queue.  The
+     * returned value will include leased messages.
+     * 
+     * @param conn The {@link Connection} to use.
+     * 
+     * @return The number of messages in the message queue (including leased
+     *         messages).
+     * 
+     * @throws SQLException If a database failure occurs.
+     */
+    default int getMessageCount(Connection conn) throws SQLException {
+        PreparedStatement ps = null;
+        ResultSet         rs = null;
+        try {
+            // check if we can find at least one row
+            ps = conn.prepareStatement(
+                "SELECT COUNT(*) FROM sz_message_queue");
+
+            rs = ps.executeQuery();
+
+            rs.next();
+
+            return rs.getInt(1);
+
+        } finally {
+            rs = close(rs);
+            ps = close(ps);
+        }
+    }
+
+    /**
+     * Inserts a message into the database queue.
+     * 
+     * @param conn The {@link Connection} to use.
+     * 
+     * @param messageText The text for the message.
+     * 
+     * @throws SQLException If a database failure occurs.
+     */
+    default void insertMessage(Connection conn, String messageText) throws SQLException 
+    {
+        PreparedStatement ps = null;
+        try {
+            ps = conn.prepareStatement(
+                "INSERT INTO sz_message_queue (message_text) VALUES (?)");
+
+            ps.setString(1, messageText);
+            
+            int rowCount = ps.executeUpdate();
+
+            if (rowCount != 1) {
+                throw new SQLException(
+                    "Failed to insert exactly one row: " + rowCount);
+            }
+
+        } finally {
+            ps = close(ps);
+        }
+    }
+
+    /**
+     * Updates at most the specified number of the least recently received message 
+     * rows with the specified lease ID and lease expiration time and returns the
+     * number of message rows that were leased.
+     * 
+     * @param conn The {@link Connection} to use.
+     * 
+     * @param leaseId The lease ID to use.
+     * 
+     * @param leaseTime The number of <b>seconds</b> for which the messages should be 
+     *                  leased.
+     * 
+     * @param maxLeaseCount The maximum number of info message rows to lease.
+     * 
+     * @return The number of message rows that were leased using the specified
+     *         lease ID and lease time in seconds.  This returns zero (0) if 
+     *         no rows were leased.
+     * 
+     * @throws SQLException If a database failure occurs.
+     */
+    default int leaseMessages(Connection    conn, 
+                              String        leaseId, 
+                              int           leaseTime,
+                              int           maxLeaseCount)
+        throws SQLException
+    {
+        PreparedStatement   ps      = null;
+        DatabaseType        dbType  = this.getDatabaseType();
+
+        try {
+            // prepare the statement
+            ps = conn.prepareStatement(
+                "UPDATE sz_message_queue "
+                + "SET lease_id = ?, "
+                + "expire_lease_at = " + dbType.getTimestampBindingSQL() + " "
+                + "WHERE message_id IN (SELECT message_id FROM sz_message_queue "
+                + "WHERE lease_id IS NULL AND expire_lease_at IS NULL "
+                + "ORDER BY created_on LIMIT ?)");
+            
+            // calculate the lease expiration
+            long        now         = System.currentTimeMillis();
+            long        leaseExpire = now + (leaseTime * 1000);
+            Timestamp   expireTime  = new Timestamp(leaseExpire);
+
+            // bind the statement
+            ps.setString(1, leaseId);
+            dbType.setTimestamp(ps, 2, expireTime);
+            ps.setInt(3, maxLeaseCount);
+
+            // update the row count having the lease ID
+            return ps.executeUpdate();
+
+        } finally {
+            ps = close(ps);
+        }
+    }
+
+    /**
+     * Selects the info message rows that were previously leased with the specified
+     * lease ID and returns a {@link List} of {@link LeasedMessage} instances describing
+     * thoe info message rows.
+     * 
+     * @param conn The {@link Connection} to use.
+     * 
+     * @param leaseId The lease ID to use.
+     * 
+     * @return The {@link List} of {@link LeasedMessage} instances that were selected.
+     * 
+     * @throws SQLException If a database failure occurs.
+     */
+    default List<LeasedMessage> getLeasedMessages(Connection conn, String leaseId)
+        throws SQLException
+    {
+        Objects.requireNonNull(leaseId, "Lease ID cannot be null");
+        
+        PreparedStatement   ps      = null;
+        ResultSet           rs      = null;
+        List<LeasedMessage> result  = new LinkedList<>();
+        
+        try {
+            // prepare the statement for the query of leased messages
+            ps = conn.prepareStatement(
+                "SELECT message_id, expire_lease_at, message_text "
+                + "FROM sz_message_queue "
+                + "WHERE lease_id = ?");
+
+            // bind the leae ID
+            ps.setString(1, leaseId);
+            
+            // execute the query
+            rs = ps.executeQuery();
+
+            // read the leased messages
+            while (rs.next()) {
+                long        messageId   = rs.getLong(1);
+                Timestamp   expTime     = rs.getTimestamp(2, UTC_CALENDAR);
+                String      messageText = rs.getString(3);
+
+                LeasedMessage message = new LeasedMessage(messageId,
+                                                          messageText,
+                                                          leaseId,
+                                                          expTime.getTime());
+
+                result.add(message);
+            }
+
+            // return the list of leased messages
+            return result;
+
+        } finally {
+            rs = close(rs);
+            ps = close(ps);
+        }
+    }
+    
+    /**
+     * Releases any expired leases in the databae to make them available to 
+     * this client for consumption.
+     * 
+     * @param conn The {@link Connection} to use.
+     * 
+     * @param leaseTime The number of seconds a message should be leased.
+     * 
+     * @return The number of messages for which the leases were expired.
+     * 
+     * @throws SQLException If a database failure occurs.
+     */
+    default int releaseExpiredLeases(Connection conn, int leaseTime) 
+        throws SQLException
+    {
+        PreparedStatement   ps      = null;
+        DatabaseType        dbType  = this.getDatabaseType();
+        try {
+            ps = conn.prepareStatement(
+                "UPDATE sz_message_queue "
+                + "SET lease_id = NULL, expire_lease_at = NULL "
+                + "WHERE lease_id IS NOT NULL "
+                + "AND expire_lease_at < " + dbType.getTimestampBindingSQL());
+
+            // don't be too aggressive on expiring leases
+            long        now         = System.currentTimeMillis();
+            long        leaseExpire = now - ((leaseTime * 1000) / 2);
+            Timestamp   expireTime  = new Timestamp(leaseExpire);
+
+            dbType.setTimestamp(ps, 1, expireTime);
+
+            return ps.executeUpdate();
+
+        } finally {
+            ps = close(ps);
+        }
+    }
+
+    /**
+     * Renews the lease on the specified {@link LeasedMessage}.  If the lease
+     * has already expired or the message is leased by another client then 
+     * this method returns negative-one <code>-1</code>, otherwise this method
+     * returns the UTC millisecond time for the new lease expiration.  The 
+     * specified {@link LeasedMessage} will also be modified with the new lease
+     * expiration by having its {@link LeasedMessage#extendLease(long)} method
+     * called.
+     * 
+     * @param conn The {@link Connection} to use.
+     * 
+     * @param message The {@link LeasedMessage} for which to renew the lease.
+     * 
+     * @param leaseTime The number of <b>seconds</b> to lease the message from
+     *                  the point of renewal.
+     * 
+     * @return The new UTC millisecond time for the new lease expiration, or 
+     *         negative-one (<code>-1</code>) if the lease could not be renewed.
+     *  
+     * @throws SQLException If a database failure occurs.
+     */
+    default long renewLease(Connection conn, LeasedMessage message, int leaseTime) 
+        throws SQLException
+    {
+        PreparedStatement   ps      = null;
+        DatabaseType        dbType  = this.getDatabaseType();
+        try {
+            // prepare the statement
+            ps = conn.prepareStatement(
+                "UPDATE sz_message_queue SET expire_lease_at = " 
+                + dbType.getTimestampBindingSQL()
+                + " WHERE message_id = ? AND lease_id = ?");
+            
+            // calculate the expiration time
+            long        now         = System.currentTimeMillis();
+            long        leaseExpire = now + (leaseTime * 1000);
+            Timestamp   expireTime  = new Timestamp(leaseExpire);
+
+            // bind the statement
+            dbType.setTimestamp(ps, 1, expireTime);
+            ps.setLong(2, message.getMessageId());
+            ps.setString(3, message.getLeaseId());
+            
+            int rowCount = ps.executeUpdate();
+
+            // check if the message is already expired or leased by another or missing
+            if (rowCount == 0) return -1L;
+
+            // check if somehow we updated more than row (should not be possible)
+            if (rowCount > 1) {
+                throw new SQLException(
+                    "Unexpectedly updasted more than row for message and lease ID.  "
+                    + "messageId=[ " + message.getMessageId() + " ], leaseId=[ "
+                    + message.getLeaseId() + " ], rowCount=[ " + rowCount + " ]");
+            }
+
+            // extend the lease on the LeasedMessage
+            message.extendLease(leaseExpire);
+
+            // return the new lease expiration time
+            return leaseExpire;
+
+        } finally {
+            ps = close(ps);
+        }
+    }
+
+    /**
+     * Deletes a message from the database message queue.
+     * 
+     * @param conn The {@link Connection} to use.
+     * 
+     * @param messageId The message ID for the message.
+     * 
+     * @param leaseId The optional lease ID to prevent deletion if the lease ID
+     *                on the message has changed, or <code>null</code> if the message
+     *                should be deleted regardless of the lease ID.
+     *                 
+     * @return <code>true</code> if a message was deleted, otherwise
+     *         <code>false</code>.
+     * 
+     * @throws SQLException If a database failure occurs.
+     */
+    default boolean deleteMessage(Connection conn, long messageId, String leaseId)
+        throws SQLException 
+    {
+        PreparedStatement ps = null;
+        try {
+            ps = conn.prepareStatement(
+                "DELETE FROM sz_message_queue WHERE message_id = ?"
+                + ((leaseId != null) ? " AND lease_id = ?" : ""));
+
+            ps.setLong(1, messageId);
+            if (leaseId != null) {
+                ps.setString(2, leaseId);
+            }    
+
+            int rowCount = ps.executeUpdate();
+
+            if (rowCount > 1) {
+                throw new SQLException(
+                    "Somehow deleted more than one message row.  messageId=[ "
+                    + messageId + " ], leaseId=[ " + leaseId + " ], rowCount=[ "
+                    + rowCount + " ]");
+            }
+
+            return (rowCount == 1);
+
+        } finally {
+            ps = close(ps);
+        }
+    }
+
+}

--- a/src/main/java/com/senzing/listener/communication/sql/SQLConsumer.java
+++ b/src/main/java/com/senzing/listener/communication/sql/SQLConsumer.java
@@ -1,0 +1,1097 @@
+package com.senzing.listener.communication.sql;
+
+import java.io.File;
+import java.util.List;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Instant;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonArray;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonArrayBuilder;
+import javax.naming.NameNotFoundException;
+
+import com.senzing.sql.ConnectionProvider;
+import com.senzing.sql.DatabaseType;
+import com.senzing.sql.Connector;
+import com.senzing.sql.SQLiteConnector;
+import com.senzing.sql.PostgreSqlConnector;
+import com.senzing.sql.ConnectionPool;
+import com.senzing.sql.ConnectionProvider;
+import com.senzing.sql.PoolConnectionProvider;
+
+import com.senzing.text.TextUtilities;
+import com.senzing.listener.communication.AbstractMessageConsumer;
+import com.senzing.listener.communication.exception.MessageConsumerException;
+import com.senzing.listener.communication.exception.MessageConsumerSetupException;
+import com.senzing.listener.service.MessageProcessor;
+import com.senzing.util.AccessToken;
+import com.senzing.util.JsonUtilities;
+import com.senzing.naming.Registry;
+
+import static java.lang.Boolean.*;
+import static com.senzing.sql.SQLUtilities.*;
+import static com.senzing.util.LoggingUtilities.*;
+import static com.senzing.listener.communication.MessageConsumer.State.*;
+
+/**
+ * A consumer for a SQL-based message queue using a database table to hold
+ * the pending messages.
+ */
+public class SQLConsumer extends AbstractMessageConsumer<LeasedMessage> {
+  /**
+   * Provides an interface for interacting with the message queue used
+   * by the associated {@link SQLConsumer}. 
+   */
+  public static interface MessageQueue {
+    /**
+     * Checks if the message queue is empty.
+     * 
+     * @throws SQLException If a database failure occurs.
+     */
+    boolean isEmpty() throws SQLException;
+
+    /**
+     * Gets the number of messages currently in the message queue.  The
+     * returned value will include leased messages.
+     * 
+     * @return The number of messages in the message queue (including leased
+     *         messages).
+     * 
+     * @throws SQLException If a database failure occurs.
+     */
+    int getMessageCount() throws SQLException;
+
+    /**
+     * Enqueues a message on this {@link MessageQueue} so the associated
+     * {@link SQLConsumer} can consume it.
+     * 
+     * @param message The message to enqueue.
+     * 
+     * @throws SQLException If a SQL failure occurs.
+     */
+    void enqueueMessage(String message) throws SQLException;
+
+    /**
+     * Gets the associated {@link SQLConsumer}.
+     * 
+     * @return The associated {@link SQLConsumer}.
+     */
+    SQLConsumer getSQLConsumer();
+  }
+
+  /**
+   * Provides a {@link MessageQueue} implementation that is backed
+   * by the {@link SQLClient} for the associated {@link SQLConsumer}.
+   * 
+   */
+  protected class SimpleMessageQueue implements MessageQueue {
+    /**
+     * The {@link SQLClient} backing this instance.
+     */
+    private SQLClient client = null;
+
+    /**
+     * Constructs with the {@link SQLClient} to use.
+     * 
+     * @param client The {@link SQLClient} to use.
+     */
+    protected SimpleMessageQueue(SQLClient client) {
+      this.client = client;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Implemented to call {@link SQLClient#isQueueEmpty(Connection)}
+     * on the backing {@link SQLClient}.
+     * </p>
+     */
+    public boolean isEmpty() throws SQLException {
+      Connection conn = null;
+      try {
+        conn = SQLConsumer.this.getConnection();
+
+        return this.client.isQueueEmpty(conn);
+
+      } finally {
+        conn = close(conn);
+      }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Implemented to call {@link SQLClient#getMessageCount(Connection)}
+     * on the backing {@link SQLClient}.
+     * </p>
+     */
+    public int getMessageCount() throws SQLException {
+      Connection conn = null;
+      try {
+        conn = SQLConsumer.this.getConnection();
+
+        return this.client.getMessageCount(conn);
+
+      } finally {
+        conn = close(conn);
+      }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Implemented to call {@link SQLClient#insertMessage(Connection,String)}
+     * on the backing {@link SQLClient}.
+     * </p>
+     */
+    public void enqueueMessage(String message) throws SQLException
+    {
+      Connection conn = null;
+      try {
+        conn = SQLConsumer.this.getConnection();
+
+        this.client.insertMessage(conn, message);
+
+        conn.commit();
+
+      } finally {
+        conn = close(conn);
+      }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public SQLConsumer getSQLConsumer() {
+      return SQLConsumer.this;
+    }
+  }
+
+  /**
+   * {@link Registry} used to register the {@link MessageQueue} instances
+   * assocaited with each {@link SQLConsumer}.  In order to register the
+   * {@link MessageQueue} the {@link #QUEUE_REGISTRY_NAME_KEY} initialization 
+   * parameter must be provided for the {@link SQLConsumer}.
+   */
+  public static Registry<MessageQueue> MESSAGE_QUEUE_REGISTRY 
+      = new Registry<>(false);
+
+  /**
+   * The initialization parameter key used to obtain the name for binding 
+   * the {@link MessageQueue} instance for interacting with the backing
+   * message queue of the {@link SQLConsumer} in the {@link 
+   * #MESSAGE_QUEUE_REGISTRY}.  There is no default value for this
+   * initialization parameter, if it is not specified then the {@link
+   * MessageQueue} is not registered in the {@link #MESSAGE_QUEUE_REGISTRY}.
+   * The {@link MessageQueue} is unbound when the {@link SQLConsumer} is
+   * destroyed.
+   */
+  public static final String QUEUE_REGISTRY_NAME_KEY = "queueRegistryName";
+
+  /**
+   * The initialization parameter key for checking if the persistent store
+   * of messages should be dropped / deleted and recreated during
+   * initialization.  Values should be <code>true</code> or <code>false</code>.
+   */
+  public static final String CLEAN_DATABASE_KEY = "cleanDatabase";
+
+  /**
+   * The initialization parameter key for obtaining the {@link
+   * ConnectionProvider} to use for connecting to the database from the
+   * {@link ConnectionProvider#REGISTRY}.
+   */
+  public static final String CONNECTION_PROVIDER_KEY = "connectionProvider";
+
+  /**
+   * The initialization parameter to configure the maximum number of times to
+   * retry a failed attempt to select messages from the database before
+   * aborting consumption.
+   */
+  public static final String MAXIMUM_RETRIES_KEY = "maximumRetries";
+
+  /**
+   * The initialization parameter to configure the number of milliseconds to
+   * wait to retry when a failure occurs.  This is only matters if the
+   * configured {@linkplain #MAXIMUM_RETRIES_KEY failure threshold} is
+   * greater than one (1).
+   */
+  public static final String RETRY_WAIT_TIME_KEY = "retryWaitTime";
+
+  /**
+   * The initialization parameter to configure the number of <b>seconds</b>
+   * messages are leased on the database table before they become available
+   * to another consumer instance.  If not configured then {@link 
+   * #DEFAULT_LEASE_TIME} is used.  Specifying this initialization parameter
+   * allows the clients to override.
+   */
+  public static final String LEASE_TIME_KEY = "leaseTime";
+
+  /**
+   * The initialization parameter to configure the maximum number of messages
+   * to be leased from the database table at one time.  If not configured
+   * then {@link #DEFAULT_MAXIMUM_LEASE_COUNT} is used.  Specifying this
+   * initialization parameter allows clients to override.
+   */
+  public static final String MAXIMUM_LEASE_COUNT_KEY = "maximumLeaseCount";
+
+  /**
+   * The initialization parameter to configure the maximum number of 
+   * <b>seconds</b> to sleep when the database queue is found to be empty 
+   * in order to avoid a busy loop of constant queries.  The actual amount
+   * of time used for sleep will progessively increase as the message
+   * queue continues to be empty until it equals the configured maximum
+   * number of seconds.  If not configured then {@link 
+   * #DEFAULT_MAXIMUM_SLEEP_TIME} is used.  Specifying this initialization
+   * parameter allows clients to override.
+   */
+  public static final String MAXIMUM_SLEEP_TIME_KEY = "maximumSleepTime";
+
+  /**
+   * The default number of times to retry failed SQS requests before aborting
+   * consumption.  The default value is {@value}.  A different value can be set
+   * via the {#link #MAXIMUM_RETRIES_KEY} initialization parameter.
+   */
+  public static final int DEFAULT_MAXIMUM_RETRIES = 0;
+
+  /**
+   * The default number of milliseconds to wait before retrying the SQS request
+   * if the previous request failed.  The default value is {@value}.  A
+   * different value can be set via the {@link #RETRY_WAIT_TIME_KEY} 
+   * initialization parameter.
+   */
+  public static final long DEFAULT_RETRY_WAIT_TIME = 1000L;
+
+ /**
+   * The default number of seconds to lease a message in the database table,
+   * preventing other consumers from obtaining it.  The default value is {@value}.
+   * A different value can be set via the {@link #LEASE_TIME_KEY} initialization
+   * parameter.
+   */
+  public static final int DEFAULT_LEASE_TIME = 1800;
+
+  /**
+   * The default maximum number of messages to be leased from the database table
+   * at one time.  The default value is {@value}.  A different value can be set
+   * via the {@link #MAXIMUM_LEASE_COUNT_KEY} initialization parameter.
+   */
+  public static final int DEFAULT_MAXIMUM_LEASE_COUNT = 100;
+
+  /**
+   * The default maximum number of second to sleep when an empty queue is
+   * encountered in order to avoid a busy loop of querying the database.
+   * The actual amount of time used for sleep will progessively increase 
+   * as the message queue continues to be empty until it equals the
+   * configured maximum number of seconds.  The default value is {@value}.
+   * A different value can be set via the {@link #MAXIMUM_SLEEP_TIME_KEY}
+   * initialization parameter.
+   */
+  public static final int DEFAULT_MAXIMUM_SLEEP_TIME = 10;
+
+  /**
+   * Defined constant for one second in milliseconds.
+   */
+  private static final long ONE_SECOND = 1000L;
+
+  /**
+   * The {@link ConnectionProvider} to use for obtaining
+   * {@link Connection} instances.
+   */
+  private ConnectionProvider connectionProvider;
+
+  /**
+   * The {@link MessageQueue} for this instance.
+   */
+  private MessageQueue messageQueue;
+
+  /**
+   * The name for binding the {@link #messageQueue} in the {@link
+   * #MESSAGE_QUEUE_REGISTRY}.
+   */
+  private String queueRegistryName = null;
+
+  /**
+   * The {@link AccessToken} for unbinding the {@link #messageQueue} from the
+   * {@link #MESSAGE_QUEUE_REGISTRY}.
+   */
+  private AccessToken registryToken = null;
+
+  /**
+   * The {@link SQLClient} to use for interacting with the database.
+   */
+  private SQLClient sqlClient;
+  
+  /**
+   * The consumption thread for this instance.
+   */
+  private Thread consumptionThread = null;
+
+  /**
+   * The maximum number of times to retry failed SQS requests before aborting
+   * consumption.
+   */
+  private int maximumRetries = DEFAULT_MAXIMUM_RETRIES;
+
+  /**
+   * The number of milliseconds to wait before retrying the SQS request if the
+   * previous request failed.
+   */
+  private long retryWaitTime = DEFAULT_RETRY_WAIT_TIME;
+
+  /**
+   * The configured number of seconds to lease messages from the database 
+   * queue before they become available to other consumers.
+   */
+  private int leaseTime = DEFAULT_LEASE_TIME;
+
+  /**
+   * The configured maximum number of messages to lease at one time from the
+   * database queue.
+   */
+  private int maximumLeaseCount = DEFAULT_MAXIMUM_LEASE_COUNT;
+
+  /**
+   * The configured maximum number of second to sleep when an empty queue is
+   * encountered in order to avoid a busy loop of querying the database.
+   * The actual amount of time used for sleep will progessively increase 
+   * as the message queue continues to be empty until it equals the
+   * configured maximum number of seconds.
+   */
+  private int maximumSleepTime = DEFAULT_MAXIMUM_SLEEP_TIME;
+
+  /**
+   * Private default constructor.
+   */
+  public SQLConsumer() {
+    // do nothing
+  }
+
+  /**
+   * Initializes the object. It sets the object up based on configuration
+   * passed in.
+   * <p>
+   * The configuration is in JSON format:
+   * <pre>
+   * {
+   *   "connectionProvider": "&lt;provider-registry-name&gt;",
+   *   "cleanDatabase": "&lt;true|false&gt;",
+   *   "maximumRetries": "&lt;retry-count&gt;"
+   *   "retryWaitTime": "&lt;pause-milliseconds&gt;",
+   *   "leaseTime": "&lt;lease-time-seconds&gt;",
+   *   "maximumLeaseCount": "&lt;message-count&gt;",
+   *   "maximumSleepTime": "&lt;sleep-time-seconds&gt;"
+   * }
+   * </pre>
+   *
+   * @param config Configuration string containing the needed information to
+   *               connect to connect to the backing database to lease 
+   *               messages and consume them.
+   *
+   * @throws MessageConsumerSetupException If an initialization failure occurs.
+   */
+  @Override
+  protected void doInit(JsonObject config) throws MessageConsumerSetupException
+  {
+    try {
+      // check if we are cleaning the database
+      Boolean clean = getConfigBoolean(config, CLEAN_DATABASE_KEY, FALSE);
+
+      // get the connection provider name
+      String providerKey = getConfigString(config,
+                                           CONNECTION_PROVIDER_KEY,
+                                           true);
+
+
+      try {
+        this.connectionProvider = ConnectionProvider.REGISTRY.lookup(providerKey);
+      } catch (NameNotFoundException e) {
+        throw new MessageConsumerSetupException(
+            "No ConnectionProvider was registered to the name specified by the "
+            + "\"" + CONNECTION_PROVIDER_KEY + "\" initialization parameter: "
+            + providerKey);
+      }
+
+      // get the failure threshold
+      this.maximumRetries = getConfigInteger(config,
+                                             MAXIMUM_RETRIES_KEY,
+                                             0,
+                                             DEFAULT_MAXIMUM_RETRIES);
+
+      // get the retry wait time
+      this.retryWaitTime = getConfigLong(config,
+                                         RETRY_WAIT_TIME_KEY,
+                                         0L,
+                                         DEFAULT_RETRY_WAIT_TIME);
+
+      // get the lease time
+      this.leaseTime = getConfigInteger(config,
+                                        LEASE_TIME_KEY,
+                                        1,
+                                        DEFAULT_LEASE_TIME);
+
+      // get the maximum lease count
+      this.maximumLeaseCount = getConfigInteger(config,
+                                                MAXIMUM_LEASE_COUNT_KEY,
+                                                1,
+                                                DEFAULT_MAXIMUM_LEASE_COUNT);
+
+      // get the maximum sleep time
+      this.maximumSleepTime = getConfigInteger(config,
+                                               MAXIMUM_SLEEP_TIME_KEY,
+                                               1,
+                                               DEFAULT_MAXIMUM_SLEEP_TIME);
+
+      // initialize the SQLClient
+      this.sqlClient = this.initSQLClient();
+
+      // initialize the message queue interface
+      this.messageQueue = this.initMessageQueue();
+
+      // ensure the schema exists
+      this.ensureSchema(clean);
+
+      // optionally register the MessageQueue interface
+      this.queueRegistryName = getConfigString(config, 
+                                               QUEUE_REGISTRY_NAME_KEY,
+                                               false);
+
+      if (this.queueRegistryName != null) {
+        this.registryToken = MESSAGE_QUEUE_REGISTRY.bind(
+          this.queueRegistryName, this.messageQueue);
+      }
+
+    } catch (Exception e) {
+      throw new MessageConsumerSetupException(e);
+    }
+  }
+
+  /**
+   * Gets a JDBC {@link Connection} to use.  Typically these are obtained from
+   * a backing pool so repeated calls to this function without closing the
+   * previously obtained {@link Connection} instances could exhaust the pool.
+   * This may block until a {@link Connection} is available.
+   *
+   * @return The {@link Connection} that was obtained.
+   *
+   * @throws SQLException If a JDBC failure occurs.
+   */
+  protected Connection getConnection() throws SQLException {
+    return this.connectionProvider.getConnection();
+  }
+
+  /**
+   * Determines the {@link SQLClient} to use from the metadata obtained
+   * from the JDBC {@link Connection} via {@link #getConnection()} and
+   * returns the {@link SQLClient} instance.
+   * 
+   * @return The {@link SQLClient} to use.
+   * 
+   * @throws MessageConsumerSetupException If a failure occurs.
+   */
+  protected SQLClient initSQLClient() throws MessageConsumerSetupException
+  {
+    Connection conn = null;
+    try {
+      // get a connection
+      conn = this.getConnection();
+
+      // set the database type
+      DatabaseType databaseType = DatabaseType.detect(conn);
+
+      // create the SQLClient instance
+      switch (databaseType) {
+        case POSTGRESQL:
+          return new PostgreSQLClient();
+        case SQLITE:
+          return new SQLiteClient();
+        default:
+          throw new MessageConsumerSetupException(
+            "The configured ConnectionProvider is associated with unsupported "
+            + "database type.  databaseType=[ " + databaseType + " ]");
+      }
+
+    } catch (SQLException e) {
+      throw new MessageConsumerSetupException(
+        "Encountered a SQL failure during initialization.", e);
+
+    } finally {
+      conn = close(conn);
+    }
+  }
+
+  /**
+   * Gets the {@link SQLClient} used by this instance for interacting with the 
+   * backing database.  This returns <code>null</code> if the {@link SQLClient}
+   * has not yet been initialized.
+   * 
+   * @return The {@link SQLClient} used by this instance for interacting with 
+   *         the backing database.
+   */
+  protected SQLClient getSQLClient() {
+    return this.sqlClient;
+  }
+
+  /**
+   * Creates and initializes the {@link MessageQueue} instance to use with
+   * this {@link SQLConsumer}.
+   * 
+   * @return The {@link MessageQueue} instance that was created to be used
+   *         with this {@link SQLConsumer}.
+   */
+  protected MessageQueue initMessageQueue() {
+    return new SimpleMessageQueue(this.getSQLClient());
+  }
+
+  /**
+   * Gets the {@link MessageQueue} interface for interacting with the 
+   * backing message queue for this {@link SQLConsumer}.
+   * 
+   * @return The {@link MessageQueue} interface for interacting with the 
+   *         backing message queue for this {@link SQLConsumer}.
+   */
+  public MessageQueue getMessageQueue() {
+    return this.messageQueue;
+  }
+
+  /**
+   * Ensures the schema exists and alternatively drops the existing the schema
+   * and recreates it.  This is called from {@link #doInit(JsonObject)}.
+   *
+   * @param recreate <code>true</code> if the existing schema should be
+   *                 dropped, otherwise <code>false</code>.
+   *
+   * @throws SQLException If a failure occurs.
+   */
+  protected void ensureSchema(boolean recreate) throws SQLException {
+    Connection conn = null;
+    try {
+      // get the connection
+      conn = this.getConnection();
+
+      // get the SQLClient
+      SQLClient sqlClient = this.getSQLClient();
+
+      // ensure the schema exists
+      sqlClient.ensureSchema(conn, recreate);
+
+    } finally {
+      conn = close(conn);
+    }
+  }
+
+  /**
+   * Returns the maximum number times failed attempts to connect to the database
+   * will be retried before aborting message consumption.  This defaults to {@link
+   * #DEFAULT_MAXIMUM_RETRIES} and can be configured via the
+   * {@link #MAXIMUM_RETRIES_KEY} configuration parameter.
+   *
+   * @return The maximum number of times failed attempts to connect to the database
+   *         will be retried before aborting message consumption.
+   */
+  public int getMaximumRetries() {
+    return this.maximumRetries;
+  }
+
+  /**
+   * Returns the number of milliseconds to wait between database query retries
+   * when a failure occurs.  This defaults to {@link #DEFAULT_RETRY_WAIT_TIME}
+   * and can be configured via the {@link #RETRY_WAIT_TIME_KEY} configuration
+   * parameter.
+   *
+   * @return The number of milliseconds to wait between databae query retries
+   *         when a failure occurs.
+   */
+  public long getRetryWaitTime() {
+    return this.retryWaitTime;
+  }
+
+  /**
+   * Gets the number of <b>seconds</b> messages will be leased from the
+   * database queue, preventing other processores from consuming those same
+   * messages until the lease has expired.
+   *
+   * @return The number of <b>seconds</b> messages will be leased from the
+   *         database queue, preventing other processores from consuming those
+   *         same messages until the lease has expired.
+   */
+  public int getLeaseTime() { return this.leaseTime; }
+
+  /**
+   * Gets the maximum number of messages to lease from the database queue
+   * at one time.
+   * 
+   * @return The maximum number of messages to lease from the database 
+   *         queue at one time.
+   */
+  public int getMaximumLeaseCount() { 
+    return this.maximumLeaseCount;
+  }
+
+  /**
+   * Gets the maximum number of <b>seconds</b> to sleep when an empty queue
+   * is encountered.   The actual amount of time used for sleep will 
+   * progessively increase as the message queue continues to be empty until
+   * it equals the configured maximum number of seconds.
+   * 
+   * @return The maximum number of <b>seconds</b> to sleep when an empty queue
+   *         is encountered.
+   */
+  public int getMaximumSleepTime() {
+    return this.maximumSleepTime;
+  }
+
+  /**
+   * Creates a virtually unique lease ID.
+   *
+   * @return A new lease ID to use.
+   */
+  protected String generateLeaseId() {
+    long pid = ProcessHandle.current().pid();
+    StringBuilder sb = new StringBuilder();
+    sb.append(pid).append("|").append(Instant.now().toString()).append("|");
+    sb.append(TextUtilities.randomAlphanumericText(50));
+    return sb.toString();
+  }
+
+  /**
+   * Handles an SQL failure and checks if consumption should be aborted.
+   *
+   * @param failureCount The number of consecutive failures so far.
+   * @param failure The {@link Exception} that was thrown if available,
+   *                otherwise <code>null</code>.
+   * @return <code>true</code> if consumption should abort, otherwise
+   *         <code>false</code>.
+   */
+  protected boolean handleFailure(int failureCount, Exception failure)
+  {
+    // get the maximum number of retries
+    int maxRetries = this.getMaximumRetries();
+
+    logWarning(failure,
+               "FAILURE DETECTED: " + failureCount + " of " + maxRetries
+                   + " consecutive failure(s)");
+
+    // check if we have exceeded the maximum failure count
+    if (failureCount > maxRetries) {
+      // return true to indicate that we should abort consumption
+      return true;
+
+    } else {
+      // looks like we can retry
+      try {
+        Thread.sleep(this.getRetryWaitTime());
+      } catch (InterruptedException ignore) {
+        // ignore the exception
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Implemented to launch a background thread that will read messages from
+   * the database queue and process them.
+   * 
+   * @param processor Processes messages
+   * 
+   * @throws MessageConsumerException If a failure occurs.
+   */
+  @Override
+  protected void doConsume(MessageProcessor processor)
+      throws MessageConsumerException
+  {
+    this.consumptionThread = new Thread(() -> {
+      int   failureCount  = 0;
+      long  sleepTime     = 1000L;
+      while (this.getState() == CONSUMING) {
+        // get the SQLClient
+        SQLClient sqlClient = this.getSQLClient();
+
+        // generate a lease ID
+        String leaseId = this.generateLeaseId();
+
+        // get the lease time (in seconds)
+        int leaseTime = this.getLeaseTime();
+
+        // get the maximum lease count
+        int maxLeaseCount = this.getMaximumLeaseCount();
+
+        // initialize the messages list
+        List<LeasedMessage> messages = null;
+
+        // initialize the connection
+        Connection conn = null;
+          
+        try {
+          // get the connection
+          conn = this.getConnection();
+
+          // first release any expired leases so we can lease those messages
+          int count = sqlClient.releaseExpiredLeases(conn, leaseTime);
+          
+          // commit the transaction
+          conn.commit();
+
+          if (count > 0) {
+            logInfo("expired leases on " + count + " messages");
+          }
+
+          // lease messages
+          count = sqlClient.leaseMessages(
+            conn, leaseId, leaseTime, maxLeaseCount);
+
+          // commit and close the connection so the leases are marked
+          // and the connection is available
+          conn.commit();
+          conn = close(conn);
+
+          // check if we have an empty queue
+          if (count == 0) {
+            failureCount = 0;
+            try {
+              Thread.sleep(sleepTime);
+            } catch (InterruptedException ignore) {
+              // do nothing
+            }
+            sleepTime = sleepTime * 2L;
+            long maxSleepTime = 1000L * ((long) this.getMaximumSleepTime());
+
+            if (sleepTime > maxSleepTime) {
+              sleepTime = maxSleepTime;
+            }
+            
+            // try again
+            continue;
+          }
+
+          // we got a non-empty queue so retore the sleep time to one second
+          sleepTime = ONE_SECOND;
+
+          // get the connection 
+          conn = this.getConnection();
+
+          // get the list of leased messages
+          messages = sqlClient.getLeasedMessages(conn, leaseId);
+
+          // close the connection
+          conn = close(conn);
+
+        } catch (SQLException e) {
+          if (this.handleFailure(++failureCount, e)) {
+            // destroy and then return to abort consumption
+            this.destroy();
+            return;
+
+          } else {
+            // let's retry
+            continue;
+          }
+        } finally {
+          // close the connection
+          conn = close(conn);
+        }
+          
+        // if we get here then we have leased messages without a failure
+        // so we reset the failure count
+        failureCount = 0;
+
+        // get the messages from the response
+        for (LeasedMessage message : messages) {
+          // enqueue the next message for processing -- this call may wait
+          // for enough room in the queue for the messages to be enqueued
+          this.enqueueMessages(processor, message);
+        }
+      }
+    });
+
+    // start the thread
+    this.consumptionThread.start();
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Overridden to renew the lease when a message is dequeued.
+   * </p>
+   */
+  @Override
+  protected synchronized InfoMessage<LeasedMessage> dequeueMessage(
+    MessageProcessor processor)
+  {
+    // get the message
+    InfoMessage<LeasedMessage> message = super.dequeueMessage(processor);
+
+    // check if we got a message and renew its lease
+    if (message != null) {
+      Connection conn = null;
+      try {
+        // get a connection
+        conn = this.getConnection();
+
+        // get the SQLClient
+        SQLClient sqlClient = this.getSQLClient();
+
+        // get the lease time
+        int leaseTime = this.getLeaseTime();
+
+        // get the leased message
+        LeasedMessage leasedMessage = message.getBatch().getMessage();
+
+        // renew the lease
+        sqlClient.renewLease(conn, leasedMessage, leaseTime);
+
+        // commit the connection
+        conn.commit();
+
+      } catch (SQLException e) {
+        logWarning(e, "Ignoring exception while renewing message lease:", message);
+
+      } finally {
+        conn = close(conn);
+      }
+    }
+
+    // return the message
+    return message;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected String extractMessageBody(LeasedMessage message) {
+    return message.getMessageText();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected void disposeMessage(LeasedMessage message) {
+    Connection conn = null;
+    try {
+      // get the connection
+      conn = this.getConnection();
+
+      // get the SQLClient
+      SQLClient sqlClient = this.getSQLClient();
+
+      // get the message ID and lease ID
+      long    messageId = message.getMessageId();
+      String  leaseId   = message.getLeaseId();
+
+      // delete the message
+      sqlClient.deleteMessage(conn, messageId, leaseId);
+
+      // commit the transaction
+      conn.commit();
+
+    } catch (Exception e) {
+      logWarning(e, "Ignoring exception while acknowledging message:", message);
+
+    } finally {
+      conn = close(conn);
+    }
+  }
+
+  @Override
+  protected void doDestroy() {
+    // join to the consumption thread
+    try {
+      this.consumptionThread.join();
+      synchronized (this) {
+        this.consumptionThread = null;
+      }
+
+      // unregister the the message queue if registered
+      if (this.registryToken != null && this.queueRegistryName != null
+          && MESSAGE_QUEUE_REGISTRY.isBound(this.queueRegistryName))
+      {
+        try {
+          MESSAGE_QUEUE_REGISTRY.unbind(this.queueRegistryName, 
+                                        this.registryToken);
+          this.registryToken      = null;
+          this.queueRegistryName  = null;
+        } catch (Exception e) {
+          logWarning(e, "Ignoring exception while unbinding MessageQueue.");
+        }
+      }
+
+    } catch (InterruptedException ignore) {
+      // ignore
+    }
+  }
+
+  /**
+   * Provides a means to test this class from the command-line.
+   * 
+   * @param args The command-line arguments.
+   */
+  public static void main(String[] args) {
+    // check if no arguments specified
+    if (args.length != 1 && args.length !=2 && args.length != 6) {
+      System.err.println("Unexpected number of command-line arguments.");
+      printUsage();
+      System.exit(1);
+    }
+
+    try {
+      DatabaseType dbType = DatabaseType.valueOf(args[0]);
+
+      Connector connector   = null;
+      int       minPoolSize = 1;
+      int       maxPoolSize = 1;
+      switch (dbType) {
+        case SQLITE:
+          if (args.length == 1) {
+            SQLiteConnector conn = new SQLiteConnector();
+            File file = conn.getSqliteFile();
+            System.out.println("SQLite File: " + file);
+            connector = conn;
+
+          } else if (args.length == 2) {
+            connector = new SQLiteConnector(args[1]);
+          } else {
+            System.err.println("Unexpected number of command-line arguments.");
+            printUsage();
+            System.exit(1);
+          }
+          break;
+        case POSTGRESQL:
+          if (args.length != 6) {
+            System.err.println("Unexpected number of command-line arguments.");
+            printUsage();
+            System.exit(1);
+          }
+          String  host      = args[1];
+          int     port      = Integer.parseInt(args[2]);
+          String  database  = args[3];
+          String  user      = args[4];
+          String  password  = args[5];
+
+          connector = new PostgreSqlConnector(
+            host, port, database, user, password);
+          minPoolSize = 2;
+          maxPoolSize = 5;
+
+          break;
+        default:
+          System.err.println("Unsupported database type: " + dbType);
+          printUsage();
+          System.exit(1);
+          break;
+      }
+
+      ConnectionPool pool 
+        = new ConnectionPool(connector, minPoolSize, maxPoolSize);
+
+      ConnectionProvider provider = new PoolConnectionProvider(pool);
+      
+      ConnectionProvider.REGISTRY.bind("test-provider", provider);
+      
+      JsonObjectBuilder builder = Json.createObjectBuilder();
+      builder.add(CLEAN_DATABASE_KEY, false);
+      builder.add(CONNECTION_PROVIDER_KEY, "test-provider");
+      builder.add(QUEUE_REGISTRY_NAME_KEY, "message-queue");
+
+      JsonObject config = builder.build();
+
+      SQLConsumer consumer = new SQLConsumer();
+      consumer.init(config);
+
+      consumer.consume((jsonMessage) -> {
+        String recordId = jsonMessage.getString("RECORD_ID");
+        JsonArray array = jsonMessage.getJsonArray("AFFECTED_ENTITIES");
+        for (JsonObject obj : array.getValuesAs(JsonObject.class)) {
+          long entityId = obj.getJsonNumber("ENTITY_ID").longValue();
+
+          System.out.println();
+          System.out.println(
+            "ENTITY ID: " + entityId + " / RECORD ID: " + recordId);
+        }
+      });
+
+      MessageQueue messageQueue 
+        = SQLConsumer.MESSAGE_QUEUE_REGISTRY.lookup("message-queue");
+
+      int entityId = 10;
+      int recordId = 100000;
+      int messageCount = 0;
+      for (int index1 = 0; index1 < 100; index1++) {
+        JsonArrayBuilder jab = Json.createArrayBuilder();
+        for (int index2 = 0; index2 < 15; index2++) {
+          JsonObjectBuilder job = Json.createObjectBuilder();
+          job.add("DATA_SOURCE", "CUSTOMERS");
+          job.add("RECORD_ID", String.valueOf(recordId++));
+
+          JsonArrayBuilder jab2 = Json.createArrayBuilder();
+
+          JsonObjectBuilder job2 = Json.createObjectBuilder();
+          job2.add("ENTITY_ID", entityId++);
+          jab2.add(job2);
+          job.add("AFFECTED_ENTITIES", jab2);
+          
+          jab.add(job);
+        }
+        String message = JsonUtilities.toJsonText(jab);
+        messageQueue.enqueueMessage(message);
+        messageCount++;
+      }
+
+      System.out.println();
+      System.out.println("ENQUEUED " + messageCount + " MESSAGES");
+
+      // wait until the queue is empty
+      for (int index = 0; !messageQueue.isEmpty(); index++) {
+        Thread.sleep(1000L);
+        if (index % 10 == 0) {
+          java.util.Map<Statistic,Number> statistics = consumer.getStatistics();
+          System.out.println();
+          System.out.println("------------------------------");
+          statistics.forEach((stat, value) -> {
+            System.out.println(
+              stat.getName() + " : " + value + " " + stat.getUnits());
+          });
+          System.out.println();
+          System.out.println("QUEUE SIZE  : " + messageQueue.getMessageCount());
+          System.out.println("------------------------------");
+        }
+      }
+
+      System.out.println();
+      System.out.println("QUEUE EMPTY : " + messageQueue.isEmpty());
+      System.out.println("QUEUE SIZE  : " + messageQueue.getMessageCount());
+
+      // destroy the consumer
+      consumer.destroy();
+      pool.shutdown();
+
+    } catch (Exception e) {
+      e.printStackTrace();
+      printUsage();
+      System.exit(1);
+    }
+  }
+
+  /**
+   * 
+   */
+  private static void printUsage() {
+    System.err.println();
+    System.err.println("COMMAND-LINE ARGUMENT OPTIONS: ");
+    System.err.println(
+      "  - For SQLite with an auto-created temporary file:");
+    System.err.println(
+      "       SQLITE");
+    System.err.println(
+      "  - For SQLite with a specific database file:");
+    System.err.println(
+      "       SQLITE <sqlite-file-path>");
+    System.err.println(
+      "  - For PostrgreSQL:");
+    System.err.println(
+      "       POSTGRESQL <db-host> <db-port> <db-name> <db-user> <db-password>");
+    System.err.println();
+  }
+}

--- a/src/main/java/com/senzing/listener/communication/sql/SQLiteClient.java
+++ b/src/main/java/com/senzing/listener/communication/sql/SQLiteClient.java
@@ -1,0 +1,114 @@
+package com.senzing.listener.communication.sql;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.ArrayList;
+
+import com.senzing.sql.DatabaseType;
+
+import static com.senzing.sql.SQLUtilities.*;
+import static com.senzing.util.LoggingUtilities.*;
+
+/**
+ * Provides a SQLite implementation of {@link SQLClient}.
+ */
+public class SQLiteClient implements SQLClient {
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Implemented to return {@link DatabaseType#SQLITE}.
+     * </p>
+     */
+    @Override
+    public DatabaseType getDatabaseType() {
+        return DatabaseType.SQLITE;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Implemented to create the schema for the SQLite database.
+     * <p>
+     */
+    @Override
+    public void ensureSchema(Connection conn, boolean recreate) 
+        throws SQLException 
+    {
+        String createTableSql = "CREATE TABLE IF NOT EXISTS sz_message_queue ( "
+            + "message_id INTEGER PRIMARY KEY, "
+            + "lease_id TEXT, "
+            + "expire_lease_at TIMESTAMP,"
+            + "message_text TEXT NOT NULL,"
+            + "created_on TIMESTAMP NOT NULL "
+            + "DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')), "
+            + "modified_on TIMESTAMP NOT NULL "
+            + "DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')))";
+    
+       String dropTableSql = "DROP TABLE IF EXISTS sz_message_queue";
+
+       String createIndexSql = "CREATE INDEX IF NOT EXISTS sz_msg_queue_lease "
+            + "ON sz_message_queue (lease_id)";
+
+       String dropIndexSql = "DROP INDEX IF EXISTS sz_msg_queue_lease";
+
+       String createUpdateTriggerSql = "CREATE TRIGGER IF NOT EXISTS "
+            + "sz_msg_queue_mod AFTER UPDATE "
+            + "ON sz_message_queue FOR EACH ROW "
+            + "BEGIN UPDATE sz_message_queue "
+            + "SET created_on = old.created_on,"
+            + " modified_on = (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')) "
+            + " WHERE message_id = old.message_id; END;";
+
+       String dropUpdateTriggerSql = "DROP TRIGGER IF EXISTS sz_msg_queue_mod";
+
+       String createInsertTriggerSql = "CREATE TRIGGER IF NOT EXISTS "
+            + "sz_msg_queue_create AFTER INSERT "
+            + "ON sz_message_queue FOR EACH ROW "
+            + "BEGIN UPDATE sz_message_queue "
+            + "SET created_on = (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),"
+            + " modified_on = (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')) "
+            + " WHERE message_id = new.message_id; END;";
+
+       String dropInsertTriggerSql = "DROP TRIGGER IF EXISTS sz_msg_queue_create";
+
+       List<String> sqlList = new ArrayList<>();
+
+       if (recreate) {
+           sqlList.add(dropInsertTriggerSql);
+           sqlList.add(dropUpdateTriggerSql);
+           sqlList.add(dropIndexSql);
+           sqlList.add(dropTableSql);
+       }
+       sqlList.add(createTableSql);
+       sqlList.add(createIndexSql);
+       sqlList.add(createUpdateTriggerSql);
+       sqlList.add(createInsertTriggerSql);
+      
+       // execute the statements
+       Statement stmt = null;
+       try {
+           // create the statement
+           stmt = conn.createStatement();
+
+           // execute the SQL statements
+           for (String sql : sqlList) {
+               try {
+                   stmt.execute(sql);
+               } catch (SQLException e) {
+                   logError(e, "SQL Error Encountered: ", sql);
+                   throw e;
+               }
+           }
+
+           // commit the connection
+           conn.commit();
+
+       } finally {
+           stmt = close(stmt);
+       }
+    }
+}

--- a/src/main/java/com/senzing/listener/communication/sqs/SQSConsumer.java
+++ b/src/main/java/com/senzing/listener/communication/sqs/SQSConsumer.java
@@ -231,8 +231,11 @@ public class SQSConsumer extends AbstractMessageConsumer<Message> {
                                   ReceiveMessageResponse  response,
                                   Exception               failure)
   {
+    // get the maximum number of retries
+    int maxRetries = this.getMaximumRetries();
+    
     logWarning(failure,
-               "FAILURE DETECTED: " + failureCount
+               "FAILURE DETECTED: " + failureCount + " of " + maxRetries
                    + " consecutive failure(s)",
                ((response != null)
                    ? ("Received SQS HTTP error response code: "
@@ -242,7 +245,7 @@ public class SQSConsumer extends AbstractMessageConsumer<Message> {
                "SQS URL: " + this.getSqsUrl());
 
     // check if we have exceeded the maximum failure count
-    if (failureCount > this.getMaximumRetries()) {
+    if (failureCount > maxRetries) {
       // return true to indicate that we should abort consumption
       return true;
 

--- a/src/main/java/com/senzing/listener/service/AbstractListenerService.java
+++ b/src/main/java/com/senzing/listener/service/AbstractListenerService.java
@@ -443,7 +443,7 @@ public abstract class AbstractListenerService implements ListenerService
           this.getDefaultSchedulingServiceClassName());
 
       // get the scheduling service Class object from the class name
-      Class schedServiceClass = Class.forName(className);
+      Class<?> schedServiceClass = Class.forName(className);
 
       if (!SchedulingService.class.isAssignableFrom(schedServiceClass)) {
         throw new ServiceSetupException(

--- a/src/main/java/com/senzing/listener/service/g2/G2Service.java
+++ b/src/main/java/com/senzing/listener/service/g2/G2Service.java
@@ -262,7 +262,7 @@ public class G2Service {
       String    initConfig      = null;
       switch (initConfigValue.getValueType()) {
         case STRING:
-          initConfig = getG2IniDataAsJson(config.getString(G2_INIT_CONFIG_KEY));
+          initConfig = getG2InitDataAsJson(config.getString(G2_INIT_CONFIG_KEY));
           break;
         case OBJECT:
           initConfig = toJsonText(config.getJsonObject(G2_INIT_CONFIG_KEY));
@@ -651,7 +651,7 @@ public class G2Service {
    * @return The JSON text.
    * @throws IOException If an I/O failure occurs.
    */
-  protected static String getG2IniDataAsJson(String initConfig)
+  public static String getG2InitDataAsJson(String initConfig)
       throws IOException
   {
     String trimmed = initConfig.trim();


### PR DESCRIPTION
- Changed `sqlite-jdbc` dependency to version `3.42.0.1` to avoid the problematic
  version `3.43.x.x` which carelessly breaks backwards compatibility by removing
  functionality that has been supported for sixteen (16) years. 
- Added `com.senzing.listener.communication.sql.SQLConsumer` implementation of 
  `com.senzing.listener.communication.MessageConsumer`.  
- Made `G2Service.getG2InitDataAsJson(String)` function `public` and renamed the
  function from `getG2IniDataAsJson(String)`
- Added `ConsumerType.DATABASE` enumerated constant for `SQLConsumer`.
- Updated `MessageConsumerFactory` to support `ConsumerType.DATABASE` constant 
  and creation of `SQLConsumer` instances.

Issues Resolved:
Resolves #118 