### PR TITLE
Version 0.5.4 Release -- Updated dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.4] - 2024-01-10
+
+### Changed in 0.5.4
+
+- Updated dependency versions:
+  - Updated AWS dependencies to version `2.22.12`
+  - Updated `maven-compiler-plugin` to version `3.12.1`
+  - Updated `maven-surefire-plugin` to version `3.2.3`
+  - Updated `maven-javadoc-plugin` to version `3.6.3`
+
 ## [0.5.3] - 2023-12-07
 
 ### Changed in 0.5.3
@@ -20,12 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ConsumerType.DATABASE` enumerated constant for `SQLConsumer`.
 - Updated `MessageConsumerFactory` to support `ConsumerType.DATABASE` constant 
   and creation of `SQLConsumer` instances.
-- Updated dependency versions:
-  - Updated AWS dependencies to version `2.22.12`
-  - Updated `maven-compiler-plugin` to version `3.12.1`
-  - Updated `maven-surefire-plugin` to version `3.2.3`
-  - Updated `maven-javadoc-plugin` to version `3.6.3`
-
 
 ## [0.5.2] - 2023-10-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `ConsumerType.DATABASE` enumerated constant for `SQLConsumer`.
 - Updated `MessageConsumerFactory` to support `ConsumerType.DATABASE` constant 
   and creation of `SQLConsumer` instances.
+- Updated dependency versions:
+  - Updated AWS dependencies to version `2.22.12`
+  - Updated `maven-compiler-plugin` to version `3.12.1`
+  - Updated `maven-surefire-plugin` to version `3.2.3`
+  - Updated `maven-javadoc-plugin` to version `3.6.3`
+
 
 ## [0.5.2] - 2023-10-13
 

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>[3.1.4, 3.999.999]</version>
+      <version>[3.1.5, 3.999.999]</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>senzing-listener</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.3</version>
+  <version>0.5.4</version>
   <name>Senzing Listener Framework</name>
   <description>Framework for creating applications receiving messages from G2 through queue</description>
   <url>http://github.com/Senzing/senzing-listener</url>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.21.40</version>
+        <version>2.22.12</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -94,77 +94,77 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sqs</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>auth</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-query-protocol</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>protocol-core</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sdk-core</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>aws-core</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>regions</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>json-utils</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>annotations</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>utils</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>http-client-spi</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>metrics-spi</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>endpoints-spi</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>profiles</artifactId>
-      <version>2.21.40</version>
+      <version>2.22.12</version>
     </dependency>
     <dependency>
       <groupId>software.amazon.eventstream</groupId>
@@ -209,7 +209,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.11.0</version>
+        <version>3.12.1</version>
         <configuration>
           <compilerArgs>
             <arg>-Xlint:unchecked</arg>
@@ -220,7 +220,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.3</version>
         <configuration>
           <systemPropertyVariables>
             <project.build.directory>${project.build.directory}</project.build.directory>
@@ -252,7 +252,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.6.3</version>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
- Updated dependency versions:
  - Updated AWS dependencies to version `2.22.12`
  - Updated `maven-compiler-plugin` to version `3.12.1`
  - Updated `maven-surefire-plugin` to version `3.2.3`
  - Updated `maven-javadoc-plugin` to version `3.6.3`
